### PR TITLE
ActiveRecord, Redis 周りの不要な記述を除去

### DIFF
--- a/config/unicorn/development.rb
+++ b/config/unicorn/development.rb
@@ -22,12 +22,6 @@ end
 preload_app true
 
 before_fork do |server, worker|
-  # the following is highly recomended for Rails + "preload_app true"
-  # as there's no need for the master process to hold a connection
-  if defined?(ActiveRecord::Base)
-    ActiveRecord::Base.connection.disconnect!
-  end
-
   # Before forking, kill the master process that belongs to the .oldbin PID.
   # This enables 0 downtime deploys.
   old_pid = "#{server.config[:pid]}.oldbin"
@@ -37,15 +31,5 @@ before_fork do |server, worker|
     rescue Errno::ENOENT, Errno::ESRCH
       # someone else did our job for us
     end
-  end
-end
-
-after_fork do |server, worker|
-  if defined?(ActiveRecord::Base)
-    ActiveRecord::Base.establish_connection
-  end
-
-  if defined?(Redis.current) and Redis.current.client.respond_to?(:reconnect)
-    Redis.current.client.reconnect
   end
 end


### PR DESCRIPTION
`a-know-home` に関しては今のところ DB , Redis の利用は無いため、コピペして持ってきてしまったこれらの記述を削除する。