### PR TITLE
bot からのアクセスのときは /knock を叩かせない

### DIFF
--- a/app/controllers/knock_controller.rb
+++ b/app/controllers/knock_controller.rb
@@ -13,6 +13,20 @@ class KnockController < ApplicationController
           "Language : #{params['language']}"
         ].join("\n")
       }
-    ) unless params['admin']
+    ) if want_to_knock?
+  end
+
+  private
+
+  def want_to_knock?
+    !(admin? || from_bot?)
+  end
+
+  def admin?
+    params['admin'].present? && params['admin'] == 'true'
+  end
+
+  def from_bot?
+    params['user_agent'].include?('bot.html')
   end
 end

--- a/spec/request/knock_spec.rb
+++ b/spec/request/knock_spec.rb
@@ -31,7 +31,21 @@ RSpec.describe '/knock', type: :request do
         {
           user_agent: 'USER_AGENT_STRING',
           language: 'LANGUAGE_STRING',
-          admin: true,
+          admin: 'true',
+        }
+      end
+
+      it 'should not post fluent_logger' do
+        expect(fluent_logger).to_not receive(:post)
+        subject
+      end
+    end
+
+    context 'user_agent includes `bot.html`' do
+      let(:params) do
+        {
+          user_agent: 'USER_AGEbot.htmlNT_STRING',
+          language: 'LANGUAGE_STRING',
         }
       end
 


### PR DESCRIPTION
#35 

「bot からのアクセス」は、UA に `bot.html` が含まれているか、とした。