### PR TITLE
ブログの各種メトリクスを fluentd に送る頻度を調節する

### DIFF
--- a/app/controllers/blog_metricks_controller.rb
+++ b/app/controllers/blog_metricks_controller.rb
@@ -8,6 +8,8 @@ class BlogMetricksController < SendToFluentController
   DUMMY_UA = 'Opera/9.80 (Windows NT 5.1; U; ja) Presto/2.7.62 Version/11.01'
 
   def count_bookmarks
+    return unless every_15min?
+
     response_header = `curl -i -A '#{DUMMY_UA}' http://b.hatena.ne.jp/bc/gr/http://blog.a-know.me/`
     response_header =~ /Location: (.+)\r\n/
     image_url = $1
@@ -18,6 +20,8 @@ class BlogMetricksController < SendToFluentController
   end
 
   def count_subscribers
+    return unless every_15min?
+
     ldr_hateda = ldr_check(Net::HTTP.get(URI.parse(LDR_ENDPOINT + HATEDA_RSS)).to_i)
     ldr_hateblo_feed = ldr_check(Net::HTTP.get(URI.parse(LDR_ENDPOINT + HATEBLO_FEED)).to_i)
     ldr_hateblo_rss  = ldr_check(Net::HTTP.get(URI.parse(LDR_ENDPOINT + HATEBLO_RSS)).to_i)

--- a/app/controllers/send_to_fluent_controller.rb
+++ b/app/controllers/send_to_fluent_controller.rb
@@ -1,9 +1,18 @@
 class SendToFluentController < ActionController::API
+  SEND_FREQUENCY_MIN = 15
+
   def fluent_logger(primary_tag)
     @logger ||= if Rails.env == 'test'
                 Fluent::Logger::TestLogger.new(primary_tag)
               else
                 Fluent::Logger::FluentLogger.new(primary_tag)
               end
+  end
+
+  private
+
+  def every_15min?
+    min = DateTime.now.min
+    min % SEND_FREQUENCY_MIN == 0
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,4 +39,8 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
   config.include ActiveSupport::Testing::TimeHelpers
+
+  config.after(:each) do
+    travel_back
+  end
 end


### PR DESCRIPTION
#47 に関連

Mackerel からは変わらず毎分叩かせて、 fluentd に送るかどうかはアプリで判定する