### PR TITLE
Against load error

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -13,6 +13,5 @@ require ::File.expand_path('../config/environment', __FILE__)
 
 # Action Cable uses EventMachine which requires that all classes are loaded in advance
 Rails.application.eager_load!
-require 'action_cable/process/logging'
 
 run Rails.application


### PR DESCRIPTION
```
/var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/activesupport-5.0.0.beta2/lib/active_support/dependencies.rb:302:in `require': cannot load such file -- action_cable/process/logging (LoadError)
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/activesupport-5.0.0.beta2/lib/active_support/dependencies.rb:302:in `block in require'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/activesupport-5.0.0.beta2/lib/active_support/dependencies.rb:268:in `load_dependency'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/activesupport-5.0.0.beta2/lib/active_support/dependencies.rb:302:in `require'
	from /var/www/a-know-home/releases/20160218000243/config.ru:16:in `block in <main>'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/rack-2.0.0.alpha/lib/rack/builder.rb:55:in `instance_eval'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/rack-2.0.0.alpha/lib/rack/builder.rb:55:in `initialize'
	from /var/www/a-know-home/releases/20160218000243/config.ru:in `new'
	from /var/www/a-know-home/releases/20160218000243/config.ru:in `<main>'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/rack-2.0.0.alpha/lib/rack/builder.rb:49:in `eval'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/rack-2.0.0.alpha/lib/rack/builder.rb:49:in `new_from_string'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/rack-2.0.0.alpha/lib/rack/builder.rb:40:in `parse_file'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/rack-2.0.0.alpha/lib/rack/server.rb:318:in `build_app_and_options_from_config'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/rack-2.0.0.alpha/lib/rack/server.rb:218:in `app'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/server.rb:58:in `app'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/rack-2.0.0.alpha/lib/rack/server.rb:353:in `wrapped_app'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/server.rb:136:in `log_to_stdout'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/server.rb:76:in `start'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:90:in `block in server'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:85:in `tap'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:85:in `server'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/command.rb:20:in `run'
	from /var/www/a-know-home/shared/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands.rb:19:in `<top (required)>'
	from bin/rails:9:in `require'
	from bin/rails:9:in `<main>'
```

rails の issue #23367 かな