### PR TITLE
Twitter cards にリベンジ

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Twitter Cards -->
+    <meta name="twitter:card" content="photo" />
+    <meta name="twitter:site" content="@a_know" />
+    <meta name="twitter:title" content="a-know's Public Contributions Graph" />
+    <meta name="twitter:image" content="https://grass-graph.shitemil.works/images/a-know.png" />
+    <meta name="twitter:url" content="https://grass-graph.shitemil.works/" />
+
     <title>えいのうのいえ | a-know's Resume / Portfolio page</title>
     <!-- Bootstrap -->
     <link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
#79 のリベンジ。

https://github.com/a-know/a-know-home-server/pull/83 で、grass-graph 画像に拡張付きでアクセスできるようにしたので、これでダメか試してみる。
仮にダメでも今回は revert せずにほっとく。