### PR TITLE
type オプションを指定できるようにした。

### DIFF
--- a/app/controllers/grass_graph_controller.rb
+++ b/app/controllers/grass_graph_controller.rb
@@ -22,7 +22,7 @@ class GrassGraphController < ActionController::API
       page_response = Net::HTTP.get(URI.parse("https://github.com/#{github_id}"))
       page_response.gsub!(
         /^[\s\S]+<svg.+class="js-calendar-graph-svg">/,
-        '<svg xmlns="http://www.w3.org/2000/svg" width="720" height="135" class="js-calendar-graph-svg">')
+        %Q|<svg xmlns="http://www.w3.org/2000/svg" width="720" height="#{svg_height}" class="js-calendar-graph-svg">|)
       page_response.gsub!(
         /dy="87" style="display: none;">S<\/text>[\s\S]+<\/g>[\s\S]+<\/svg>[\s\S]+\z/,
         'dy="87" style="display: none;">S</text><text x="553" y="110">Less</text><g transform="translate(587 , 0)"><rect class="day" width="11" height="11" y="99" fill="#eeeeee"/></g><g transform="translate(602 , 0)"><rect class="day" width="11" height="11" y="99" fill="#d6e685"/></g><g transform="translate(617 , 0)"><rect class="day" width="11" height="11" y="99" fill="#8cc665"/></g><g transform="translate(632 , 0)"><rect class="day" width="11" height="11" y="99" fill="#44a340"/></g><g transform="translate(647 , 0)"><rect class="day" width="11" height="11" y="99" fill="#1e6823"/></g><text x="666" y="110">More</text></g></svg>')
@@ -40,11 +40,24 @@ class GrassGraphController < ActionController::API
     File.open(tmpfile_path(github_id)).read
   end
 
+  # experimental
+  def type
+    params['type'] == 'detail' ? 'detail' : 'graph'
+  end
+
   private
+
+  def detail_type?
+    type == 'detail'
+  end
+
+  def svg_height
+    detail_type? ? 375 : 135
+  end
 
   def tmpfile_path(github_id)
     dir_name = github_id == 'a-know' ? 'gg_svg' : 'gg_others_svg'
-    "./tmp/#{dir_name}/#{github_id}_#{Time.now.strftime('%Y-%m-%d')}.svg"
+    "./tmp/#{dir_name}/#{github_id}_#{Time.now.strftime('%Y-%m-%d')}_#{type}.svg"
   end
 
   def upload_gcs(github_id, path)
@@ -65,11 +78,11 @@ class GrassGraphController < ActionController::API
   end
 
   def generate_png(svg_data, rotate, height, width)
-    png_data = ImageConvert.svg_to_png(svg_data, 720, 135)
+    png_data = ImageConvert.svg_to_png(svg_data, 720, svg_height)
 
-    if rotate || width || height
-      width  = width  ? width.to_i : 720
-      height = height ? height.to_i : 135
+    if rotate || width || height || detail_type?
+      width  = width  ? width.to_i : resize_width
+      height = height ? height.to_i : svg_height
 
       image = MiniMagick::Image.read(png_data)
       image.combine_options do |b|
@@ -79,6 +92,10 @@ class GrassGraphController < ActionController::API
       png_data = image.to_blob
     end
     png_data
+  end
+
+  def resize_width
+    detail_type? ? 560 : 720
   end
 
   class ImageConvert

--- a/app/controllers/grass_graph_controller.rb
+++ b/app/controllers/grass_graph_controller.rb
@@ -48,6 +48,7 @@ class GrassGraphController < ActionController::API
   end
 
   def upload_gcs(github_id, path)
+    return unless Rails.env.production?
     require 'gcloud'
     dir_name = github_id == 'a-know' ? 'my-gg-svg' : nil
     return unless dir_name

--- a/spec/controllers/grass_graph_controller_spec.rb
+++ b/spec/controllers/grass_graph_controller_spec.rb
@@ -20,19 +20,30 @@ RSpec.describe GrassGraphController do
       allow(controller).to receive(:tmpfile_path).with(github_id).and_return(dummy_tmpfile)
     end
 
-    context 'svg 抽出済みのファイルが既に存在する場合' do
-      before { FileUtils.copy('spec/files/extracted.svg', dummy_tmpfile) unless File.exists?(dummy_tmpfile) }
+    context 'type=graph オプションが指定された場合' do
+      before { allow(controller).to receive(:type).and_return('graph') }
+      context 'svg 抽出済みのファイルが既に存在する場合' do
+        before { FileUtils.copy('spec/files/extracted.svg', dummy_tmpfile) unless File.exists?(dummy_tmpfile) }
 
-      it 'public contributions のグラフを svg 形式でファイルに出力したもの（既に存在するもの）の内容を返す・GCS へのアップロードは行わない' do
-        expect(controller).to_not receive(:upload_gcs).with(github_id, dummy_tmpfile)
-        expect(controller.extract_svg(github_id)).to eq File.read('spec/files/expect.svg')
+        it 'public contributions のグラフを svg 形式でファイルに出力したもの（既に存在するもの）の内容を返す・GCS へのアップロードは行わない' do
+          expect(controller).to_not receive(:upload_gcs).with(github_id, dummy_tmpfile)
+          expect(controller.extract_svg(github_id)).to eq File.read('spec/files/expect.svg')
+        end
+      end
+
+      context 'svg 抽出済みのファイルがまだ存在しない場合' do
+        it 'public contributions のグラフを svg 形式でファイルに出力したもの（今回新たに取得したもの）の内容を返す・GCS へのアップロードも行う' do
+          expect(controller).to receive(:upload_gcs).with(github_id, dummy_tmpfile)
+          expect(controller.extract_svg(github_id)).to eq File.read('spec/files/expect.svg')
+        end
       end
     end
 
-    context 'svg 抽出済みのファイルがまだ存在しない場合' do
-      it 'public contributions のグラフを svg 形式でファイルに出力したもの（今回新たに取得したもの）の内容を返す・GCS へのアップロードも行う' do
-        expect(controller).to receive(:upload_gcs).with(github_id, dummy_tmpfile)
-        expect(controller.extract_svg(github_id)).to eq File.read('spec/files/expect.svg')
+    context 'type=detail オプションが指定された場合' do
+      before { allow(controller).to receive(:type).and_return('detail') }
+
+      it 'detail に適したサイズの宣言が含まれていること' do
+        expect(controller.extract_svg(github_id)).to match /width="720" height="375"/
       end
     end
   end


### PR DESCRIPTION
関連 #78 

560x292 くらいのサイズがちょうどよいという、twitter cards 向け。experimental。

`/images/a-know?type=detail` のようにすると、560x292 の画像が返ってくる、それだけ。
これで twitter cards の表示がうまくできそうなら、detail のときだけ streak の情報を追加したりしたい