### PR TITLE
type=detail のオプションを表向きには見せないことにした

### DIFF
--- a/public/gglp/css/custom.css
+++ b/public/gglp/css/custom.css
@@ -6,3 +6,8 @@
 .services.section-padding {
   background-color: #fff;
 }
+
+.gg-img {
+  width: 100%;
+  height: auto;
+}

--- a/public/gglp/css/main.css
+++ b/public/gglp/css/main.css
@@ -310,7 +310,7 @@ a:hover {
 .about {
     position: relative;
     background: #8BC34A;
-    padding: 10px 0;
+    padding: 10px 0 30px 0;
 }
 .about h2 {
     text-align: center;

--- a/public/gglp/index.html
+++ b/public/gglp/index.html
@@ -106,7 +106,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-sm-8 col-sm-offset-2" id="gg-img-area">
-                    <img src="https://grass-graph.shitemil.works/images/a-know.png">
+                    <img src="https://grass-graph.shitemil.works/images/a-know.png" class="gg-img">
                     <h2 class='description'><small>a-know's GitHub Public Contributions Grass-Graph</small></h2>
                 </div>
             </div>

--- a/public/gglp/index.html
+++ b/public/gglp/index.html
@@ -97,10 +97,6 @@
                     <h2 class="description"><small>You can specify the angle and size, to rotate or resize the image.</small></h2>
                     <input type="text" class="form-control" name="gg-img-tag-option" id="gg-img-tag-option" placeholder='<img src="https://grass-graph.shitemil.works/images/a-know.png?rotate=270&width=568&height=88">' required>
                 </div>
-                <div class="col-sm-8 col-sm-offset-2">
-                    <h2 class="description"><small>Also, you can get detail image by "type=detail" option.</small></h2>
-                    <input type="text" class="form-control" name="gg-img-tag-detail" id="gg-img-tag-detail" placeholder='<img src="https://grass-graph.shitemil.works/images/a-know.png?type=detail">' required>
-                </div>
             </div>
         </div>
     </section>
@@ -110,12 +106,8 @@
         <div class="container">
             <div class="row">
                 <div class="col-sm-8 col-sm-offset-2" id="gg-img-area">
-                    <h2 class='description'><small>a-know's GitHub Public Contributions Grass-Graph</small></h2>
                     <img src="https://grass-graph.shitemil.works/images/a-know.png">
-                </div>
-                <div class="col-sm-8 col-sm-offset-2" id="gg-img-area-detail">
-                    <h2 class='description'><small>type=detail</small></h2>
-                    <img src="https://grass-graph.shitemil.works/images/a-know.png?type=detail">
+                    <h2 class='description'><small>a-know's GitHub Public Contributions Grass-Graph</small></h2>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
機能的にはまだ殺していない。

ついでに、画面幅によっては表示が崩れる件を対応してみた。

refs #107 #109 