### PR TITLE
不正な GitHub ID を指定された場合の対策

### DIFF
--- a/app/controllers/grass_graph_controller.rb
+++ b/app/controllers/grass_graph_controller.rb
@@ -19,7 +19,13 @@ class GrassGraphController < ActionController::API
   def extract_svg(github_id)
     retry_count = 0
     while !( File.exists?(tmpfile_path(github_id)) && File.size(tmpfile_path(github_id)) != 0)
-      page_response = Net::HTTP.get(URI.parse("https://github.com/#{github_id}"))
+      begin
+        target_uri = URI.parse("https://github.com/#{github_id}")
+      rescue
+        github_id = 'a-know'
+        target_uri = URI.parse("https://github.com/#{github_id}")
+      end
+      page_response = Net::HTTP.get(target_uri)
       contributions_info = page_response.scan(%r|<span class="contrib-number">(.+)</span>|)
       page_response.gsub!(
         /^[\s\S]+<svg.+class="js-calendar-graph-svg">/,

--- a/spec/controllers/grass_graph_controller_spec.rb
+++ b/spec/controllers/grass_graph_controller_spec.rb
@@ -79,10 +79,13 @@ RSpec.describe GrassGraphController do
 
         context '不正な GitHub ID が指定されていた場合' do
           let(:github_id)  { '<github_id>' }
-          
+
           it 'id:a-know として正常処理を行うこと' do
-            expect(controller).to receive(:upload_gcs).with(github_id, dummy_tmpfile)
-            expect(controller.extract_svg(github_id)).to eq File.read('spec/files/expect.svg')
+            allow(controller).to receive(:tmpfile_path).with('a-know').and_return(dummy_tmpfile)
+            expect(controller).to receive(:upload_gcs).with('a-know', dummy_tmpfile)
+
+            svg = controller.extract_svg(github_id)
+            expect(svg).to eq File.read('spec/files/expect.svg')
             expect(svg).to include %Q|<text font-family="Helvetica" x="5" y="110">Less</text><g transform="translate(39 , 0)"><rect class="day" width="11" height="11" y="99" fill="#eeeeee"/></g><g transform="translate(54 , 0)"><rect class="day" width="11" height="11" y="99" fill="#d6e685"/></g><g transform="translate(69 , 0)"><rect class="day" width="11" height="11" y="99" fill="#8cc665"/></g><g transform="translate(84 , 0)"><rect class="day" width="11" height="11" y="99" fill="#44a340"/></g><g transform="translate(99 , 0)"><rect class="day" width="11" height="11" y="99" fill="#1e6823"/></g><text font-family="Helvetica" x="118" y="110">More</text>|
             expect(svg).to include %Q|<text x="620" y="110" font-size="18px">42 days</text>|
           end

--- a/spec/controllers/grass_graph_controller_spec.rb
+++ b/spec/controllers/grass_graph_controller_spec.rb
@@ -76,6 +76,17 @@ RSpec.describe GrassGraphController do
           svg = controller.extract_svg(github_id)
           expect(svg).to include %Q|<text x="620" y="110" font-size="18px">42 days</text>|
         end
+
+        context '不正な GitHub ID が指定されていた場合' do
+          let(:github_id)  { '<github_id>' }
+          
+          it 'id:a-know として正常処理を行うこと' do
+            expect(controller).to receive(:upload_gcs).with(github_id, dummy_tmpfile)
+            expect(controller.extract_svg(github_id)).to eq File.read('spec/files/expect.svg')
+            expect(svg).to include %Q|<text font-family="Helvetica" x="5" y="110">Less</text><g transform="translate(39 , 0)"><rect class="day" width="11" height="11" y="99" fill="#eeeeee"/></g><g transform="translate(54 , 0)"><rect class="day" width="11" height="11" y="99" fill="#d6e685"/></g><g transform="translate(69 , 0)"><rect class="day" width="11" height="11" y="99" fill="#8cc665"/></g><g transform="translate(84 , 0)"><rect class="day" width="11" height="11" y="99" fill="#44a340"/></g><g transform="translate(99 , 0)"><rect class="day" width="11" height="11" y="99" fill="#1e6823"/></g><text font-family="Helvetica" x="118" y="110">More</text>|
+            expect(svg).to include %Q|<text x="620" y="110" font-size="18px">42 days</text>|
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Grass-Graph をその利用例とともにブログに紹介したら http://blog.a-know.me/entry/2016/04/22/091857 、その利用例を Google かなにかのクローラーがクロールするたびに変なリクエストになってエラーとなり、slack に通知がきてウザいので、その対応。

不正な ID はいったんすべて a-know として扱うように修正。