### PR TITLE
過去日付を指定してグラフ画像を取得できるようにする

### DIFF
--- a/app/controllers/grass_graph_controller.rb
+++ b/app/controllers/grass_graph_controller.rb
@@ -109,7 +109,7 @@ class GrassGraphController < ActionController::API
   end
 
   def date_string(date = nil)
-    date ||= Time.now
+    date ||= now
     @date_string ||= date.strftime('%Y-%m-%d')
   end
 
@@ -132,9 +132,14 @@ class GrassGraphController < ActionController::API
   end
 
   def gcs_dir(github_id, date = nil)
-    date ||= Time.now
+    date ||= now
     initial = github_id[0]
     "gg-svg-data/#{date.strftime('%Y')}/#{date.strftime('%m')}/#{date.strftime('%d')}/#{initial}"
+  end
+
+  def now
+    # against issue #137
+    Time.now - 10.minutes
   end
 
   def integer_string?(str)

--- a/app/controllers/grass_graph_controller.rb
+++ b/app/controllers/grass_graph_controller.rb
@@ -40,7 +40,7 @@ class GrassGraphController < ActionController::API
     File.open(path).read
   end
 
-  def check_date
+  def check_date(date_str)
     begin
       Date.strptime(date_str,'%Y%m%d')
     rescue

--- a/public/gglp/css/main.css
+++ b/public/gglp/css/main.css
@@ -39,6 +39,9 @@ h4 {
 h5 {
     font-size: 18px;
 }
+h2 small {
+    font-size: 60%;
+}
 .btn {
     background-color: #8BC34A;
     color: #fff;
@@ -310,7 +313,7 @@ a:hover {
 .about {
     position: relative;
     background: #8BC34A;
-    padding: 10px 0 30px 0;
+    padding: 10px 0 0 0;
 }
 .about h2 {
     text-align: center;
@@ -320,6 +323,9 @@ a:hover {
 }
 .about h2 small {
     color: #101010;
+}
+.about h5 {
+    text-align: center;
 }
 
 /*==============================================

--- a/public/gglp/index.html
+++ b/public/gglp/index.html
@@ -97,6 +97,17 @@
                     <h2 class="description"><small>You can specify the angle and size, to rotate or resize the image.</small></h2>
                     <input type="text" class="form-control" name="gg-img-tag-option" id="gg-img-tag-option" placeholder='<img src="https://grass-graph.shitemil.works/images/a-know.png?rotate=270&width=568&height=88">' required>
                 </div>
+                <div class="col-sm-8 col-sm-offset-2">
+                    <h2 class="description"><small>In addition, you can request the past graph image with `date` parameter.</small></h2>
+                    <input type="text" class="form-control" name="gg-img-tag-option" id="gg-img-tag-option" placeholder='<img src="https://grass-graph.shitemil.works/images/a-know.png?date=20160701">' required>
+                    <h5 class="description">
+                        <small>
+                            <li>You can get image of since July 1, 2016.</li>
+                            <li>This API can return the image by recreating the cache only if you got the image on the specified day in advance.</li>
+                            <li>Therefore, I recommend you to get graph image everyday.<br>(For example, I embed my graph image tag on my blog visited by at least one visitor everyday. :)</li>
+                        </small>
+                    </h5>
+                </div>
             </div>
         </div>
     </section>

--- a/public/gglp/index.html
+++ b/public/gglp/index.html
@@ -99,7 +99,7 @@
                 </div>
                 <div class="col-sm-8 col-sm-offset-2">
                     <h2 class="description"><small>In addition, you can request the past graph image with `date` parameter.</small></h2>
-                    <input type="text" class="form-control" name="gg-img-tag-option" id="gg-img-tag-option" placeholder='<img src="https://grass-graph.shitemil.works/images/a-know.png?date=20160701">' required>
+                    <input type="text" class="form-control" name="gg-img-tag-date-option" id="gg-img-tag-date-option" placeholder='<img src="https://grass-graph.shitemil.works/images/a-know.png?date=20160701">' required>
                     <h5 class="description">
                         <small>
                             <li>You can get image of since July 1, 2016.</li>

--- a/public/gglp/js/main.js
+++ b/public/gglp/js/main.js
@@ -20,6 +20,7 @@ $("#mc-github-id").on('blur keydown keyup keypress change',function(){
   var textWrite = $("#mc-github-id").val();
   $("#gg-img-tag").val('<img src="https://grass-graph.shitemil.works/images/' + textWrite + '.png">');
   $("#gg-img-tag-option").val('<img src="https://grass-graph.shitemil.works/images/' + textWrite + '.png?rotate=270&width=568&height=88">');
+  $("#gg-img-tag-date-option").val('<img src="https://grass-graph.shitemil.works/images/' + textWrite + '.png?date=20160701">');
 });
 
 $("#generate-btn").on('click',function(){


### PR DESCRIPTION
#135 のつづき。

#### やりたいこと
* [x] 過去日付を指定してグラフ画像を取得できるようにする
* [x] grass-graph トップページにこの仕様を記載する
    * クエリストリング `date` で任意の日付を指定可能
    * 2016/07/01 以降のデータのみをサポート
    * その日最初の取得データをキャッシュ・保持する仕組みなので、画像の取得が一度も行われていない日があった場合、その日のデータは過去のデータとしても参照できない。
* [x] #137 の対策をしておく

#### マージ後 TODO
* [ ] ブログで告知する
